### PR TITLE
[feat] 챌린지 오픈 하단 버튼 스타일 지정

### DIFF
--- a/app/src/main/res/color/selector_full_width_button_background.xml
+++ b/app/src/main/res/color/selector_full_width_button_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/orange" android:state_enabled="true" />
+    <item android:color="@color/gray_2" android:state_enabled="false" />
+</selector>

--- a/app/src/main/res/color/selector_full_width_button_text.xml
+++ b/app/src/main/res/color/selector_full_width_button_text.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/white" android:state_enabled="true" />
+    <item android:color="@color/gray_3" android:state_enabled="false" />
+</selector>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -161,4 +161,20 @@
         <item name="android:letterSpacing">-0.04</item>
         <item name="android:includeFontPadding">false</item>
     </style>
+
+    <!-- Widget -->
+
+    <style name="Widget.WYB.Button.SolidButton.FullWidth" parent="Widget.MaterialComponents.Button">
+        <item name="android:layout_width">match_parent</item>
+        <item name="android:layout_height">wrap_content</item>
+        <item name="android:paddingTop">16dp</item>
+        <item name="android:paddingBottom">16dp</item>
+        <item name="android:foreground">?attr/selectableItemBackground</item>
+        <item name="android:backgroundTint">@color/selector_full_width_button_background</item>
+        <item name="android:textAppearance">@style/TextAppearance.WYBComponents.Bold.16</item>
+        <item name="android:textColor">@color/selector_full_width_button_text</item>
+        <item name="android:insetTop">0dp</item>
+        <item name="android:insetBottom">0dp</item>
+        <item name="android:stateListAnimator">@null</item>
+    </style>
 </resources>


### PR DESCRIPTION
## 📝 Changes
- 챌린지 오픈 하단에 공통적으로 사용되는 버튼의 스타일을 생성헀습니다.

## 💬 Comment
이 버튼 스타일은 `MaterialComponents.Button` 을 상속받도록 만들었습니다! 
(우리 앱의 전체적인 theme 가 _Theme.**MaterialComponents**.Light.NoActionBar_ 를 상속받고 있기 때문에!)

그런데 이 `MaterialButton` 의 background 를 `android:enabled` 속성에 따라 다르게 지정해주려면 selector 를 `/res/color` 디렉터리 하위에 만들어주고, `android:backgroundTint` 속성을 통해 이 selector 를 적용해줘야 한다고 합니다!
우리가 평소에 주로 사용하는 방법인 selector 를 `/res/drawable` 하위에 만들어주고, `android:background` 속성을 통해 적용하는 방법과는 조금 차이가 있더라고요..!!

이 버튼 스타일을 적용할 때에는
```xml
<Button
            style="@style/Widget.WYB.Button.SolidButton.FullWidth"
            android:enabled="true"
            android:text="@string/next"
            app:layout_constraintEnd_toEndOf="parent"
            app:layout_constraintStart_toStartOf="parent"
            app:layout_constraintTop_toTopOf="parent" />
```
이런 식으로 사용하면 됩니다!

## 💌 Link
https://stackoverflow.com/questions/55545824/disabled-color-state-of-material-button