### PR TITLE
[feat] WYBPopupWindow 레이아웃 및 기능 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-kapt'
+    id 'kotlin-android-extensions'
 }
 
 android {

--- a/app/src/main/java/com/wyb/wyb_android/util/Extension.kt
+++ b/app/src/main/java/com/wyb/wyb_android/util/Extension.kt
@@ -1,0 +1,9 @@
+package com.wyb.wyb_android.util
+
+import android.content.Context
+import kotlin.math.roundToInt
+
+fun convertDpToPx(context: Context, dp: Int): Int {
+    val density = context.resources.displayMetrics.density
+    return (dp.toFloat() * density).roundToInt()
+}

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBPopupWindowItemAdapter.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBPopupWindowItemAdapter.kt
@@ -6,10 +6,11 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.wyb.wyb_android.R
 import com.wyb.wyb_android.databinding.ItemWybPopupWindowBinding
+import com.wyb.wyb_android.databinding.ItemWybPopupWindowSmallBinding
 import kotlinx.android.synthetic.main.item_wyb_popup_window.view.*
 
-class WYBPopupWindowItemAdapter :
-    RecyclerView.Adapter<WYBPopupWindowItemAdapter.WYBPopupWindowItemViewHolder>() {
+class WYBPopupWindowItemAdapter(private val viewType: Int) :
+    RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     private var selectedPos = RecyclerView.NO_POSITION
     private var data = listOf(
         R.string.popup_menu_plastic_dining_utensil,
@@ -28,31 +29,51 @@ class WYBPopupWindowItemAdapter :
     override fun onCreateViewHolder(
         parent: ViewGroup,
         viewType: Int
-    ): WYBPopupWindowItemViewHolder {
-        val binding =
-            ItemWybPopupWindowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
-        return WYBPopupWindowItemViewHolder(binding, parent.context)
+    ): RecyclerView.ViewHolder {
+        return when (viewType) {
+            TYPE_POPUP_DEFAULT -> {
+                val binding =
+                    ItemWybPopupWindowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                WYBPopupWindowItemViewHolder(binding, parent.context)
+            }
+            else -> {
+                val binding =
+                    ItemWybPopupWindowSmallBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+                WYBPopupWindowItemSmallViewHolder(binding, parent.context)
+            }
+        }
     }
 
-    override fun onBindViewHolder(holder: WYBPopupWindowItemViewHolder, position: Int) {
-        holder.bind(data[position])
+    override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+        when (holder) {
+            is WYBPopupWindowItemViewHolder -> {
+                holder.bind(data[position])
 
-        if (selectedPos == RecyclerView.NO_POSITION && position == 0) {
-            selectedPos = 0
-            holder.itemView.isSelected = true
-            holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Bold_14)
-        } else {
-            if (selectedPos == position) {
-                holder.itemView.isSelected = true
-                holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Bold_14)
-            } else {
-                holder.itemView.isSelected = false
-                holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Medium_14)
+                if (selectedPos == RecyclerView.NO_POSITION && position == 0) {
+                    selectedPos = 0
+                    holder.itemView.isSelected = true
+                    holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Bold_14)
+                } else {
+                    if (selectedPos == position) {
+                        holder.itemView.isSelected = true
+                        holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Bold_14)
+                    } else {
+                        holder.itemView.isSelected = false
+                        holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Medium_14)
+                    }
+                }
+            }
+            is WYBPopupWindowItemSmallViewHolder -> {
+                holder.bind(data[position])
             }
         }
     }
 
     override fun getItemCount(): Int = data.size
+
+    override fun getItemViewType(position: Int): Int {
+        return viewType
+    }
 
     inner class WYBPopupWindowItemViewHolder(
         private val binding: ItemWybPopupWindowBinding,
@@ -67,5 +88,19 @@ class WYBPopupWindowItemAdapter :
                 notifyItemChanged(selectedPos)
             }
         }
+    }
+
+    inner class WYBPopupWindowItemSmallViewHolder(
+        private val binding: ItemWybPopupWindowSmallBinding,
+        private val context: Context
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(stringRes: Int) {
+            binding.tvItemSmall.text = context.getString(stringRes)
+        }
+    }
+
+    companion object {
+        const val TYPE_POPUP_DEFAULT = 0
+        const val TYPE_POPUP_SMALL = 1
     }
 }

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBPopupWindowItemAdapter.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBPopupWindowItemAdapter.kt
@@ -3,6 +3,7 @@ package com.wyb.wyb_android.widget
 import android.content.Context
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.RecyclerView
 import com.wyb.wyb_android.R
 import com.wyb.wyb_android.databinding.ItemWybPopupWindowBinding
@@ -49,19 +50,21 @@ class WYBPopupWindowItemAdapter(private val viewType: Int) :
             is WYBPopupWindowItemViewHolder -> {
                 holder.bind(data[position])
 
+                val tvItem = holder.itemView.tvItem
                 if (selectedPos == RecyclerView.NO_POSITION && position == 0) {
                     selectedPos = 0
                     holder.itemView.isSelected = true
-                    holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Bold_14)
+                    tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_Bold_14)
                 } else {
                     if (selectedPos == position) {
                         holder.itemView.isSelected = true
-                        holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Bold_14)
+                        tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_Bold_14)
                     } else {
                         holder.itemView.isSelected = false
-                        holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Medium_14)
+                        tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_Medium_14)
                     }
                 }
+                tvItem.setTextColor(ContextCompat.getColor(tvItem.context, R.color.gray_4))
             }
             is WYBPopupWindowItemSmallViewHolder -> {
                 holder.bind(data[position])
@@ -71,9 +74,7 @@ class WYBPopupWindowItemAdapter(private val viewType: Int) :
 
     override fun getItemCount(): Int = data.size
 
-    override fun getItemViewType(position: Int): Int {
-        return viewType
-    }
+    override fun getItemViewType(position: Int): Int = viewType
 
     inner class WYBPopupWindowItemViewHolder(
         private val binding: ItemWybPopupWindowBinding,

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBPopupWindowItemAdapter.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBPopupWindowItemAdapter.kt
@@ -1,0 +1,71 @@
+package com.wyb.wyb_android.widget
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.wyb.wyb_android.R
+import com.wyb.wyb_android.databinding.ItemWybPopupWindowBinding
+import kotlinx.android.synthetic.main.item_wyb_popup_window.view.*
+
+class WYBPopupWindowItemAdapter :
+    RecyclerView.Adapter<WYBPopupWindowItemAdapter.WYBPopupWindowItemViewHolder>() {
+    private var selectedPos = RecyclerView.NO_POSITION
+    private var data = listOf(
+        R.string.popup_menu_plastic_dining_utensil,
+        R.string.popup_menu_plastic_bag,
+        R.string.popup_menu_reuse_disposable_bag,
+        R.string.popup_menu_separate_collection,
+        R.string.popup_menu_soap,
+        R.string.popup_menu_dishcloth,
+        R.string.popup_menu_handkerchief,
+        R.string.popup_menu_unplug,
+        R.string.popup_menu_mobile_receipt,
+        R.string.popup_menu_delete_email,
+        R.string.popup_menu_input
+    )
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): WYBPopupWindowItemViewHolder {
+        val binding =
+            ItemWybPopupWindowBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return WYBPopupWindowItemViewHolder(binding, parent.context)
+    }
+
+    override fun onBindViewHolder(holder: WYBPopupWindowItemViewHolder, position: Int) {
+        holder.bind(data[position])
+
+        if (selectedPos == RecyclerView.NO_POSITION && position == 0) {
+            selectedPos = 0
+            holder.itemView.isSelected = true
+            holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Bold_14)
+        } else {
+            if (selectedPos == position) {
+                holder.itemView.isSelected = true
+                holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Bold_14)
+            } else {
+                holder.itemView.isSelected = false
+                holder.itemView.tvItem.setTextAppearance(R.style.TextAppearance_WYBComponents_PopupWindow_Medium_14)
+            }
+        }
+    }
+
+    override fun getItemCount(): Int = data.size
+
+    inner class WYBPopupWindowItemViewHolder(
+        private val binding: ItemWybPopupWindowBinding,
+        private val context: Context
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(stringRes: Int) {
+            binding.tvItem.text = context.getString(stringRes)
+
+            itemView.setOnClickListener {
+                notifyItemChanged(selectedPos)
+                selectedPos = adapterPosition
+                notifyItemChanged(selectedPos)
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/selector_wyb_popup_window_item.xml
+++ b/app/src/main/res/drawable/selector_wyb_popup_window_item.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/light_gray_1" android:state_selected="true" />
+    <item android:drawable="@android:color/transparent" android:state_selected="false" />
+</selector>

--- a/app/src/main/res/drawable/thumb_wyb_popup_window_scrollbar.xml
+++ b/app/src/main/res/drawable/thumb_wyb_popup_window_scrollbar.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:gravity="top">
+        <shape android:shape="rectangle">
+            <corners android:radius="6dp" />
+            <solid android:color="@color/light_gray_3" />
+            <size
+                android:width="3dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/app/src/main/res/layout/item_wyb_popup_window.xml
+++ b/app/src/main/res/layout/item_wyb_popup_window.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <TextView
+        android:id="@+id/tvItem"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/selector_wyb_popup_window_item"
+        android:paddingVertical="6dp"
+        android:paddingHorizontal="7dp"
+        android:textColor="@color/gray_4"
+        android:layout_marginEnd="7dp" />
+</layout>

--- a/app/src/main/res/layout/item_wyb_popup_window_small.xml
+++ b/app/src/main/res/layout/item_wyb_popup_window_small.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <TextView
+        android:id="@+id/tvItemSmall"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="7dp"
+        android:paddingHorizontal="7dp"
+        android:paddingVertical="5dp"
+        android:textAppearance="@style/TextAppearance.WYBComponents.Medium.12"
+        android:textColor="@color/dark_gray_1" />
+</layout>

--- a/app/src/main/res/layout/view_wyb_popup_window.xml
+++ b/app/src/main/res/layout/view_wyb_popup_window.xml
@@ -4,8 +4,7 @@
 
     <FrameLayout
         android:layout_width="match_parent"
-        android:layout_height="158dp"
-        android:background="@drawable/shape_orange_stroke">
+        android:layout_height="158dp">
 
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/rvItem"

--- a/app/src/main/res/layout/view_wyb_popup_window.xml
+++ b/app/src/main/res/layout/view_wyb_popup_window.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="158dp"
+        android:background="@drawable/shape_orange_stroke">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/rvItem"
+            style="@style/Widget.WYB.PopupWindow.Scrollbar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:clipToPadding="true"
+            android:paddingHorizontal="5dp"
+            android:paddingVertical="5dp"
+            tools:listitem="@layout/item_wyb_popup_window" />
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,18 @@
 
     <!-- Dialog -->
 
+    <!-- WYBPopupWindow -->
+    <string name="popup_menu_plastic_dining_utensil">플라스틱 식사도구 안 쓰기</string>
+    <string name="popup_menu_plastic_bag">비닐봉투 안 받고 안 쓰기</string>
+    <string name="popup_menu_reuse_disposable_bag">비닐봉투나 쇼핑백 재사용 하기</string>
+    <string name="popup_menu_separate_collection">분리수거 할 때 오염물이나 라벨 제거하기</string>
+    <string name="popup_menu_soap">플라스틱 통 세정제 대신 비누 사용하기</string>
+    <string name="popup_menu_dishcloth">물티슈 대신 행주나 걸레 사용하기</string>
+    <string name="popup_menu_handkerchief">핸드타올 대신 손수건 사용하기</string>
+    <string name="popup_menu_unplug">안 쓰는 전자기기 코드 뽑아 놓기</string>
+    <string name="popup_menu_mobile_receipt">종이 영수증 대신 모바일 영수증 받기</string>
+    <string name="popup_menu_delete_email">불필요한 이메일 삭제하기</string>
+    <string name="popup_menu_input">직접입력</string>
 
     <!-- HomeFragment -->
     <string name="home_bottle_title">\'s Bottle</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -162,24 +162,6 @@
         <item name="android:includeFontPadding">false</item>
     </style>
 
-    <style name="TextAppearance.WYBComponents.PopupWindow.Bold.14" parent="TextAppearance.WYBComponents">
-        <item name="fontFamily">@font/spoqa_bold</item>
-        <item name="android:fontFamily">@font/spoqa_bold</item>
-        <item name="android:textSize">14dp</item>
-        <item name="android:letterSpacing">-0.04</item>
-        <item name="android:includeFontPadding">false</item>
-        <item name="android:textColor">@color/gray_4</item>
-    </style>
-
-    <style name="TextAppearance.WYBComponents.PopupWindow.Medium.14" parent="TextAppearance.WYBComponents">
-        <item name="fontFamily">@font/spoqa_medium</item>
-        <item name="android:fontFamily">@font/spoqa_medium</item>
-        <item name="android:textSize">14dp</item>
-        <item name="android:letterSpacing">-0.04</item>
-        <item name="android:includeFontPadding">false</item>
-        <item name="android:textColor">@color/gray_4</item>
-    </style>
-
     <!-- Widget -->
 
     <style name="Widget.WYB.Button.SolidButton.FullWidth" parent="Widget.MaterialComponents.Button">

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -162,6 +162,24 @@
         <item name="android:includeFontPadding">false</item>
     </style>
 
+    <style name="TextAppearance.WYBComponents.PopupWindow.Bold.14" parent="TextAppearance.WYBComponents">
+        <item name="fontFamily">@font/spoqa_bold</item>
+        <item name="android:fontFamily">@font/spoqa_bold</item>
+        <item name="android:textSize">14dp</item>
+        <item name="android:letterSpacing">-0.04</item>
+        <item name="android:includeFontPadding">false</item>
+        <item name="android:textColor">@color/gray_4</item>
+    </style>
+
+    <style name="TextAppearance.WYBComponents.PopupWindow.Medium.14" parent="TextAppearance.WYBComponents">
+        <item name="fontFamily">@font/spoqa_medium</item>
+        <item name="android:fontFamily">@font/spoqa_medium</item>
+        <item name="android:textSize">14dp</item>
+        <item name="android:letterSpacing">-0.04</item>
+        <item name="android:includeFontPadding">false</item>
+        <item name="android:textColor">@color/gray_4</item>
+    </style>
+
     <!-- Widget -->
 
     <style name="Widget.WYB.Button.SolidButton.FullWidth" parent="Widget.MaterialComponents.Button">
@@ -176,5 +194,11 @@
         <item name="android:insetTop">0dp</item>
         <item name="android:insetBottom">0dp</item>
         <item name="android:stateListAnimator">@null</item>
+    </style>
+
+    <style name="Widget.WYB.PopupWindow.Scrollbar" parent="">
+        <item name="android:scrollbars">vertical</item>
+        <item name="android:scrollbarFadeDuration">0</item>
+        <item name="android:scrollbarThumbVertical">@drawable/thumb_wyb_popup_window_scrollbar</item>
     </style>
 </resources>


### PR DESCRIPTION
## 📝 Changes
- 불편함 드롭다운을 `PopupWindow` 를 통해 구현했습니다.
- 드롭다운 `popupWindow` 내부의 `recyclerView` 를 구현하기 위한 **`WYBPopupWindowItemAdapter`** 의 `viewType` 을 `TYPE_POPUP_DEFAULT`, `TYPE_POPUP_SMALL` 두 가지로 하여 **챌린지 오픈/진행중**에서 모두 사용할 수 있도록 했습니다.
- `popupWindow` 의 높이와 윗 여백을 `dp` 값으로 지정하기 위해 `convertDpToPx` 확장함수를 추가했습니다. (`util/extension.kt`)

## 📷 Screenshot
| 오픈 | 진행중 - stroke:orange | 진행중 - stroke:gray |
| :------------------------------: | :------------------------------: | :------------------------------: | 
| <img src="https://user-images.githubusercontent.com/52772787/162681818-aeae491a-ca35-4e3e-96fb-bdf94972b19d.png" width="240" /> | <img src="https://user-images.githubusercontent.com/52772787/162682146-54b6c02f-f6d8-4780-93ca-630ea946047d.png" width="240" /> | <img src="https://user-images.githubusercontent.com/52772787/162682139-2af92ad3-c61a-44d4-a636-234b0ea98906.png" width="240" /> |
| <img src="https://user-images.githubusercontent.com/52772787/162682583-88c20c7b-024f-405f-9c5d-1947c7c95a0f.png" width="240" /> | <img src="https://user-images.githubusercontent.com/52772787/162682891-a7a65905-da7c-4f66-9a36-a7488539cf6f.png" width="240" /> | <img src="https://user-images.githubusercontent.com/52772787/162682903-bd0beded-866f-4284-a4e4-2694abed9316.png" width="240" /> |

## 💬 Comment
**어떤 뷰(드롭다운 위 입력 박스)** 근처에 특정 크기와 위치로 **새로운 뷰(드롭다운)** 를 보여주고 싶고, **dialog 처럼 팝업 창** 으로 띄워 다른 레이아웃들이 밀려나거나 영향을 받지 않도록 하기 위해서 **`PopupWindow`** 를 사용해서 드롭다운을 구현하게 되었습니다!

`PopupWindow` 는 `PopupWindow.showAsDropDown()` 메서드를 통해 특정 View(anchor view)의 바로 아래에 팝업 창을 생성 할 수 있고, `Dialog` 와는 다르게 `PopupWindow` 가 화면에 나타나도 나머지 View 들을 사용할 수 있습니다. 또, anchor view 를 기준으로 `popupWindow` 의 width, height, x/y offset 을 설정할 수 있습니다!

이 `PopupWindow` 를 띄우는 방법입니다!

<img width="838" alt="스크린샷 2022-04-11 오후 4 34 15" src="https://user-images.githubusercontent.com/52772787/162687683-9f859a13-7152-4224-8321-3de33f847589.png">


#### 1️⃣ PopupWindow(View contentView, **`int width`**, int height, boolean focusable)
    너비를 맞추고 싶은(fill_match) anchor 뷰의 width 값을 넣어줍니다.

#### 2️⃣ PopupWindow(View contentView, int width, **`int height`**, boolean focusable)
    드롭다운의 높이를 지정합니다. 
    해당 메소드는 height 값을 px 로 지정하기 때문에, 우리가 알고 있는 dp 값을 px 로 바꾸는 과정이 필요합니다! 
    챌린지 오픈에서는 높이를 158, 진행중에서는 높이를 134로 지정해주면 됩니다.

#### 3️⃣ PopupWindow(View contentView, int width, int height, **`boolean focusable`**)
    드롭다운 외부의 영역을 클릭했을 때, 드롭다운의 dismiss 여부를 설정하는 값 입니다.
    focusable 이 true 면 외부 영역 클릭 시 드롭다운이 닫히고, false 면 닫히지 않습니다!

#### 4️⃣ PopupWindow.setBackgroundDrawable()
    드롭다운의 테두리를 지정하는 부분입니다.
    shape_orange_stroke/shape_gray4_stroke 중 선택해서 사용하면 됩니다!

#### 5️⃣ PopupWindow.showAsDropDown(View anchor, int xoff, int yoff)
    드롭다운을 띄우는 함수입니다!
    anchor 에는 기준이 될 view 를, yoff 에는 anchor 뷰와 드롭다운 사이의 세로 margin 값을 넣어주면 됩니다.
    마찬가지로 px 값을 통해 margin 값이 지정되기 때문에, dp 값을 px 로 바꾸는 과정이 필요합니다!
    드롭다운이 뷰의 아래가 아니라 위에 보여져야 할 때는
    -(anchor view 의 height(dp) + dropdown 의 height(dp) + 두 뷰 사이 margin(dp)) 처럼 음수 값을 넣어주면 됩니다!

#### 6️⃣ wybPopupWindowItemAdapter = WYBPopupWindowItemAdapter(**`TYPE_POPUP_DEFAULT`**)
    팝업 창 내부에 있는 recyclerView 의 adapter 를 초기화하는 코드입니다.
    WYBPopupWindowItemAdapter() 의 매개변수로 TYPE_POPUP_DEFAULT 를 선택하면 챌린지 오픈에서 사용되는 드롭다운의 형태를 가지게 됩니다.
    매개변수로 TYPE_POPUP_SMALL 을 선택하면 챌린지 진행중에서 사용되는 드롭다운으로 작동합니다!
    두 드롭다운의 textAppearance 와 textColor, 선택된 item 의 background 가 달라서 viewType 을 다르게 가지도록 구현했습니다!

<br>

recyclerView 의 각 item을 anchor 뷰로 해서 각각 popupWindow 를 띄워주면, recyclerView 에서도 올바른 위치에 드롭다운을 띄울 수 있을 듯 합니다! `WYBPopupWindowItemAdapter` 나 `WYBPopupWindowItemSmallViewHolder` 에서 추가적으로 구현이 필요한 부분이 있으면 더해주셔도 됩니다!!
