### PR TITLE
[feat] 챌린지 오픈 관련 화면 및 ViewModel 생성

### DIFF
--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenComfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenComfortFragment.kt
@@ -4,17 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.navGraphViewModels
 import com.wyb.wyb_android.R
 import com.wyb.wyb_android.base.BindingFragment
 import com.wyb.wyb_android.databinding.FragmentChallengeOpenComfortBinding
 
 class ChallengeOpenComfortFragment :
     BindingFragment<FragmentChallengeOpenComfortBinding>(R.layout.fragment_challenge_open_comfort) {
+    private val viewModel: ChallengeOpenViewModel by navGraphViewModels(R.id.challenge_open_nav_graph)
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
-        super.onCreateView(inflater, container, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewModel = viewModel
+
         return binding.root
     }
 }

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenComfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenComfortFragment.kt
@@ -1,0 +1,20 @@
+package com.wyb.wyb_android.ui.open
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.wyb.wyb_android.R
+import com.wyb.wyb_android.base.BindingFragment
+import com.wyb.wyb_android.databinding.FragmentChallengeOpenComfortBinding
+
+class ChallengeOpenComfortFragment :
+    BindingFragment<FragmentChallengeOpenComfortBinding>(R.layout.fragment_challenge_open_comfort) {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
@@ -1,0 +1,20 @@
+package com.wyb.wyb_android.ui.open
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.wyb.wyb_android.R
+import com.wyb.wyb_android.base.BindingFragment
+import com.wyb.wyb_android.databinding.FragmentChallengeOpenDiscomfortBinding
+
+class ChallengeOpenDiscomfortFragment :
+    BindingFragment<FragmentChallengeOpenDiscomfortBinding>(R.layout.fragment_challenge_open_discomfort) {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
@@ -4,17 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.navGraphViewModels
 import com.wyb.wyb_android.R
 import com.wyb.wyb_android.base.BindingFragment
 import com.wyb.wyb_android.databinding.FragmentChallengeOpenDiscomfortBinding
 
 class ChallengeOpenDiscomfortFragment :
     BindingFragment<FragmentChallengeOpenDiscomfortBinding>(R.layout.fragment_challenge_open_discomfort) {
+    private val viewModel: ChallengeOpenViewModel by navGraphViewModels(R.id.challenge_open_nav_graph)
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
-        super.onCreateView(inflater, container, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewModel = viewModel
+
         return binding.root
     }
 }

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenStartDateFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenStartDateFragment.kt
@@ -4,17 +4,21 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.navigation.navGraphViewModels
 import com.wyb.wyb_android.R
 import com.wyb.wyb_android.base.BindingFragment
 import com.wyb.wyb_android.databinding.FragmentChallengeOpenStartDateBinding
 
 class ChallengeOpenStartDateFragment :
     BindingFragment<FragmentChallengeOpenStartDateBinding>(R.layout.fragment_challenge_open_start_date) {
+    private val viewModel: ChallengeOpenViewModel by navGraphViewModels(R.id.challenge_open_nav_graph)
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
     ): View {
-        super.onCreateView(inflater, container, savedInstanceState)
+        binding.lifecycleOwner = viewLifecycleOwner
+        binding.viewModel = viewModel
+
         return binding.root
     }
 }

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenStartDateFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenStartDateFragment.kt
@@ -1,0 +1,20 @@
+package com.wyb.wyb_android.ui.open
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.wyb.wyb_android.R
+import com.wyb.wyb_android.base.BindingFragment
+import com.wyb.wyb_android.databinding.FragmentChallengeOpenStartDateBinding
+
+class ChallengeOpenStartDateFragment :
+    BindingFragment<FragmentChallengeOpenStartDateBinding>(R.layout.fragment_challenge_open_start_date) {
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
+    ): View {
+        super.onCreateView(inflater, container, savedInstanceState)
+        return binding.root
+    }
+}

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenViewModel.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenViewModel.kt
@@ -1,0 +1,6 @@
+package com.wyb.wyb_android.ui.open
+
+import androidx.lifecycle.ViewModel
+
+class ChallengeOpenViewModel : ViewModel() {
+}

--- a/app/src/main/res/layout/fragment_challenge_open_comfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_comfort.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.open.ChallengeOpenComfortFragment">
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_challenge_open_comfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_comfort.xml
@@ -2,6 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.wyb.wyb_android.ui.open.ChallengeOpenViewModel" />
+    </data>
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.open.ChallengeOpenDiscomfortFragment">
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
@@ -2,6 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.wyb.wyb_android.ui.open.ChallengeOpenViewModel" />
+    </data>
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_challenge_open_start_date.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_start_date.xml
@@ -2,6 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.wyb.wyb_android.ui.open.ChallengeOpenViewModel" />
+    </data>
+
     <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/app/src/main/res/layout/fragment_challenge_open_start_date.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_start_date.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".ui.open.ChallengeOpenStartDateFragment">
+
+    </FrameLayout>
+</layout>

--- a/app/src/main/res/navigation/challenge_open_nav_graph.xml
+++ b/app/src/main/res/navigation/challenge_open_nav_graph.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/challenge_open_nav_graph"
+    app:startDestination="@id/challengeOpenComfortFragment">
+
+    <fragment
+        android:id="@+id/challengeOpenComfortFragment"
+        android:name="com.wyb.wyb_android.ui.open.ChallengeOpenComfortFragment"
+        android:label="ChallengeOpenComfortFragment"
+        tools:layout="@layout/fragment_challenge_open_comfort">
+
+        <action
+            android:id="@+id/actionChallengeOpenComfortToChallengeOpenDiscomfort"
+            app:destination="@id/challengeOpenDiscomfortFragment" />
+
+    </fragment>
+
+    <fragment
+        android:id="@+id/challengeOpenDiscomfortFragment"
+        android:name="com.wyb.wyb_android.ui.open.ChallengeOpenDiscomfortFragment"
+        android:label="ChallengeOpenDiscomfortFragment"
+        tools:layout="@layout/fragment_challenge_open_discomfort">
+
+        <action
+            android:id="@+id/actionChallengeOpenDiscomfortToChallengeOpenStartDate"
+            app:destination="@id/challengeOpenStartDateFragment" />
+
+    </fragment>
+
+    <fragment
+        android:id="@+id/challengeOpenStartDateFragment"
+        android:name="com.wyb.wyb_android.ui.open.ChallengeOpenStartDateFragment"
+        android:label="ChallengeOpenStartDateFragment"
+        tools:layout="@layout/fragment_challenge_open_start_date">
+
+        <action
+            android:id="@+id/actionChallengeOpenStartDateToChallengeHome"
+            app:destination="@id/challengeFragment"
+            app:popUpTo="@id/challengeFragment"
+            app:popUpToInclusive="true" />
+
+    </fragment>
+
+</navigation>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -9,5 +9,13 @@
         android:id="@+id/challengeFragment"
         android:name="com.wyb.wyb_android.ui.home.HomeFragment"
         android:label="ChallengeFragment"
-        tools:layout ="@layout/fragment_home"/>
+        tools:layout="@layout/fragment_home">
+
+        <action
+            android:id="@+id/actionChallengeHomeToChallengeOpen"
+            app:destination="@id/challenge_open_nav_graph" />
+
+    </fragment>
+
+    <include app:graph="@navigation/challenge_open_nav_graph" />
 </navigation>


### PR DESCRIPTION
## 📝 Changes
- 챌린지 오픈과 관련된 화면을 생성했습니다
    - `ChallengeOpenComfortFragment.kt`
    - `ChallengeOpenDiscomfortFragment.kt`
    - `ChallengeOpenStartDateFragment.kt`
- 챌린지 오픈 화면 간 `navigation` 을 추가했습니다.
- 챌린지 오픈 fragment 에서 사용될 `ChallengeOpenViewModel` 을 새로 추가했습니다.

## 💬 Comment
다음으로는 챌린지 오픈 레이아웃들을 하나씩 만들고, 마지막으로 `ChallengeOpenViewModel` 에 기능 구현을 할 예정입니다! 💌