### PR TITLE
[feat] Show popup extension 제작

### DIFF
--- a/app/src/main/java/com/wyb/wyb_android/util/ShowPopupWindow.kt
+++ b/app/src/main/java/com/wyb/wyb_android/util/ShowPopupWindow.kt
@@ -6,22 +6,20 @@ import android.view.View
 import android.widget.PopupWindow
 import androidx.core.content.res.ResourcesCompat
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.wyb.wyb_android.R
 import com.wyb.wyb_android.databinding.ViewWybPopupWindowBinding
 import com.wyb.wyb_android.widget.WYBPopupWindowItemAdapter
 import com.wyb.wyb_android.widget.WYBPopupWindowItemAdapter.Companion.TYPE_POPUP_DEFAULT
+import com.wyb.wyb_android.widget.WYBPopupWindowItemAdapter.Companion.TYPE_POPUP_SMALL
 
-fun View.showPopupWindow(
-    backgroundRes: Int,
-    context: Context,
-    type: Int
+fun View.showPopupWindowDefault(
+    context: Context
 ) {
     val popupView = ViewWybPopupWindowBinding.inflate(LayoutInflater.from(context))
-    initPopupView(popupView, type, context)
+    initPopupView(popupView, TYPE_POPUP_DEFAULT, context)
 
-    val popupHeight = when (type) {
-        TYPE_POPUP_DEFAULT -> 158
-        else -> 134
-    }
+    val popupHeight: Int = resources.getInteger(R.integer.wyb_popup_window_height_default)
+    val popupMargin: Int = resources.getInteger(R.integer.wyb_popup_window_margin_default)
 
     val popup = PopupWindow(
         popupView.root,
@@ -33,11 +31,38 @@ fun View.showPopupWindow(
     popup.setBackgroundDrawable(
         ResourcesCompat.getDrawable(
             context.resources,
+            R.drawable.shape_orange_stroke,
+            null
+        )
+    )
+    popup.showAsDropDown(this, 0, convertDpToPx(context, popupMargin))
+}
+
+fun View.showPopupWindowSmall(
+    backgroundRes: Int,
+    context: Context,
+    margin: Int
+) {
+    val popupView = ViewWybPopupWindowBinding.inflate(LayoutInflater.from(context))
+    initPopupView(popupView, TYPE_POPUP_SMALL, context)
+
+    val popupHeight: Int = resources.getInteger(R.integer.wyb_popup_window_height_small)
+
+    val popup = PopupWindow(
+        popupView.root,
+        this.width,
+        convertDpToPx(context, popupHeight),
+        true
+    )
+
+    popup.setBackgroundDrawable(
+        ResourcesCompat.getDrawable(
+            context.resources,
             backgroundRes,
             null
         )
     )
-    popup.showAsDropDown(this, 0, convertDpToPx(context, 6))
+    popup.showAsDropDown(this, 0, convertDpToPx(context, margin))
 }
 
 private fun initPopupView(popupWindow: ViewWybPopupWindowBinding, type: Int, context: Context) {

--- a/app/src/main/java/com/wyb/wyb_android/util/ShowPopupWindow.kt
+++ b/app/src/main/java/com/wyb/wyb_android/util/ShowPopupWindow.kt
@@ -12,7 +12,7 @@ import com.wyb.wyb_android.widget.WYBPopupWindowItemAdapter
 import com.wyb.wyb_android.widget.WYBPopupWindowItemAdapter.Companion.TYPE_POPUP_DEFAULT
 import com.wyb.wyb_android.widget.WYBPopupWindowItemAdapter.Companion.TYPE_POPUP_SMALL
 
-fun View.showPopupWindowDefault(
+fun View.showPopupWindow(
     context: Context
 ) {
     val popupView = ViewWybPopupWindowBinding.inflate(LayoutInflater.from(context))
@@ -38,7 +38,7 @@ fun View.showPopupWindowDefault(
     popup.showAsDropDown(this, 0, convertDpToPx(context, popupMargin))
 }
 
-fun View.showPopupWindowSmall(
+fun View.showPopupWindow(
     backgroundRes: Int,
     context: Context,
     margin: Int

--- a/app/src/main/java/com/wyb/wyb_android/util/ShowPopupWindow.kt
+++ b/app/src/main/java/com/wyb/wyb_android/util/ShowPopupWindow.kt
@@ -1,0 +1,47 @@
+package com.wyb.wyb_android.util
+
+import android.content.Context
+import android.view.LayoutInflater
+import android.view.View
+import android.widget.PopupWindow
+import androidx.core.content.res.ResourcesCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.wyb.wyb_android.databinding.ViewWybPopupWindowBinding
+import com.wyb.wyb_android.widget.WYBPopupWindowItemAdapter
+import com.wyb.wyb_android.widget.WYBPopupWindowItemAdapter.Companion.TYPE_POPUP_DEFAULT
+
+fun View.showPopupWindow(
+    backgroundRes: Int,
+    context: Context,
+    type: Int
+) {
+    val popupView = ViewWybPopupWindowBinding.inflate(LayoutInflater.from(context))
+    initPopupView(popupView, type, context)
+
+    val popupHeight = when (type) {
+        TYPE_POPUP_DEFAULT -> 158
+        else -> 134
+    }
+
+    val popup = PopupWindow(
+        popupView.root,
+        this.width,
+        convertDpToPx(context, popupHeight),
+        false
+    )
+
+    popup.setBackgroundDrawable(
+        ResourcesCompat.getDrawable(
+            context.resources,
+            backgroundRes,
+            null
+        )
+    )
+    popup.showAsDropDown(this, 0, convertDpToPx(context, 6))
+}
+
+private fun initPopupView(popupWindow: ViewWybPopupWindowBinding, type: Int, context: Context) {
+    val wybPopupWindowItemAdapter = WYBPopupWindowItemAdapter(type)
+    popupWindow.rvItem.adapter = wybPopupWindowItemAdapter
+    popupWindow.rvItem.layoutManager = LinearLayoutManager(context)
+}

--- a/app/src/main/res/drawable/shape_orange_stroke.xml
+++ b/app/src/main/res/drawable/shape_orange_stroke.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
     <stroke
         android:width="1dp"
         android:color="@color/orange" />

--- a/app/src/main/res/values/integers.xml
+++ b/app/src/main/res/values/integers.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <integer name="wyb_popup_window_height_default">158</integer>
+    <integer name="wyb_popup_window_height_small">134</integer>
+    <integer name="wyb_popup_window_margin_default">6</integer>
+    <integer name="wyb_popup_window_margin_small_up">-8</integer>
+    <integer name="wyb_popup_window_margin_small_down">8</integer>
+</resources>


### PR DESCRIPTION
## 📝 Changes
- 희온과 저의 합작 !! popupWindow를 띄울때 사용하는 `showPopupWindow()` 를 extension으로 제작하였습니다. (📁util)
-  홈 화면에서 popupWindow를 띄울 때 배경이 가려지지 않는 문제로 `shape_orange_stroke.xml` 에 white  background color를 지정하였습니다.
- integer 값을 그냥 넣어주는 것보다 리소스 파일로 관리하는 게 좋을 것 같아서 `integers.xml` 리소스 파일을 새로 만들어줬습니다.!
- showPopupWindow의 type에 따라 파라미터로 넣어주는 값이 달라져야 할 것 같아서 extension 함수를 type에 따라서 각각 만들어줬습니다.

## 💌 Link
[정수 리소스 유형 관리하기](https://developer.android.com/guide/topics/resources/more-resources?hl=ko#Integer)