### PR TITLE
[feat] ChallengeOpen keyboard 및 scroll 처리 구현

### DIFF
--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenComfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenComfortFragment.kt
@@ -46,6 +46,7 @@ class ChallengeOpenComfortFragment :
     }
 
     private fun addListeners() {
+        binding.etComfort.setOnFocusChangeListener(requireActivity())
         binding.includeNavBar.btnNav.setOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
@@ -52,7 +52,7 @@ class ChallengeOpenDiscomfortFragment :
     }
 
     private fun addListeners() {
-        binding.etDiscomfort.setOnFocusChangeListener(requireActivity())
+        binding.etDiscomfort.addOnGlobalLayoutListener(binding.scrollView)
         binding.includeNavBar.btnNav.setOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
@@ -52,6 +52,7 @@ class ChallengeOpenDiscomfortFragment :
     }
 
     private fun addListeners() {
+        binding.etDiscomfort.setOnFocusChangeListener(requireActivity())
         binding.includeNavBar.btnNav.setOnClickListener {
             findNavController().popBackStack()
         }

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
@@ -64,8 +64,10 @@ class ChallengeOpenDiscomfortFragment :
         viewModel.discomfortPos.observe(viewLifecycleOwner) { position ->
             if (position == 11) {
                 binding.etDiscomfort.setTextMaxLength(MAX_INPUT_LENGTH)
+                binding.etDiscomfort.setEditTextFocusable()
             } else {
                 binding.etDiscomfort.clearTextMaxLength()
+                binding.etDiscomfort.setEditTextNotFocusable(requireActivity())
             }
         }
     }

--- a/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/open/ChallengeOpenDiscomfortFragment.kt
@@ -4,19 +4,18 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.PopupWindow
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.navGraphViewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.wyb.wyb_android.R
 import com.wyb.wyb_android.base.ViewModelFragment
 import com.wyb.wyb_android.databinding.FragmentChallengeOpenDiscomfortBinding
-import com.wyb.wyb_android.extension.showPopupWindow
 import com.wyb.wyb_android.ui.open.ChallengeOpenViewModel.Companion.MAX_INPUT_LENGTH
+import com.wyb.wyb_android.widget.adapter.WYBPopupWindowItemAdapter
 
 class ChallengeOpenDiscomfortFragment :
     ViewModelFragment<FragmentChallengeOpenDiscomfortBinding, ChallengeOpenViewModel>(R.layout.fragment_challenge_open_discomfort) {
     override val viewModel: ChallengeOpenViewModel by navGraphViewModels(R.id.challenge_open_nav_graph)
-    private lateinit var popupWindow: PopupWindow
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?
@@ -24,16 +23,11 @@ class ChallengeOpenDiscomfortFragment :
         super.onCreateView(inflater, container, savedInstanceState)
 
         initNavBar()
-        initPopupWindow()
+        initRecyclerView()
         addListeners()
         addObserver()
 
         return binding.root
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        popupWindow.dismiss()
     }
 
     private fun initNavBar() {
@@ -45,10 +39,13 @@ class ChallengeOpenDiscomfortFragment :
         }
     }
 
-    private fun initPopupWindow() {
-        binding.etDiscomfort.post {
-            popupWindow = binding.etDiscomfort.showPopupWindow(requireContext(), viewModel)
-        }
+    private fun initRecyclerView() {
+        val discomfortItemAdapter = WYBPopupWindowItemAdapter(
+            requireContext(),
+            WYBPopupWindowItemAdapter.TYPE_POPUP_DEFAULT
+        )
+        binding.rvDiscomfort.adapter = discomfortItemAdapter
+        binding.rvDiscomfort.layoutManager = LinearLayoutManager(context)
     }
 
     private fun addListeners() {

--- a/app/src/main/java/com/wyb/wyb_android/util/Utils.kt
+++ b/app/src/main/java/com/wyb/wyb_android/util/Utils.kt
@@ -32,3 +32,8 @@ fun requestFocus(context: Context?, view: View) {
         inputMethodManager.showSoftInput(view, 0)
     }
 }
+
+fun hideKeyboard(activity: Activity?, view: View) {
+    val inputMethodManager = activity?.getSystemService<InputMethodManager>() ?: return
+    inputMethodManager.hideSoftInputFromWindow(view.windowToken, 0)
+}

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
@@ -1,5 +1,6 @@
 package com.wyb.wyb_android.widget
 
+import android.app.Activity
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.text.Editable
@@ -12,6 +13,8 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import com.wyb.wyb_android.R
 import com.wyb.wyb_android.databinding.ViewWybLabelEditTextBinding
+import com.wyb.wyb_android.util.hideKeyboard
+import com.wyb.wyb_android.util.requestFocus
 
 class WYBLabelEditText @JvmOverloads constructor(
     context: Context,
@@ -107,6 +110,19 @@ class WYBLabelEditText @JvmOverloads constructor(
         backgroundStroke = when (color) {
             COLOR_GRAY -> ResourcesCompat.getDrawable(resources, R.drawable.shape_gray2_stroke, null)
             else -> ResourcesCompat.getDrawable(resources, R.drawable.shape_orange_stroke, null)
+        }
+    }
+
+    fun setOnFocusChangeListener(activity: Activity?) {
+        binding.layout.setOnFocusChangeListener { _, hasFocus ->
+            if (hasFocus) {
+                requestFocus(context, binding.etInput)
+            }
+        }
+        binding.etInput.setOnFocusChangeListener { v, hasFocus ->
+            if (!hasFocus) {
+                hideKeyboard(activity, v)
+            }
         }
     }
 

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
@@ -126,6 +126,18 @@ class WYBLabelEditText @JvmOverloads constructor(
         }
     }
 
+    fun setEditTextFocusable() {
+        binding.etInput.isFocusable = true
+        binding.etInput.isFocusableInTouchMode = true
+        requestFocus(context, binding.etInput)
+    }
+
+    fun setEditTextNotFocusable(activity: Activity?) {
+        binding.etInput.isFocusable = false
+        binding.etInput.isFocusableInTouchMode = false
+        hideKeyboard(activity, binding.etInput)
+    }
+
     companion object {
         private const val COLOR_GRAY = 0
         private const val COLOR_ORANGE = 1

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
@@ -2,6 +2,7 @@ package com.wyb.wyb_android.widget
 
 import android.app.Activity
 import android.content.Context
+import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.text.Editable
 import android.text.InputFilter
@@ -9,6 +10,7 @@ import android.text.TextWatcher
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
+import android.widget.ScrollView
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import com.wyb.wyb_android.R
@@ -87,6 +89,16 @@ class WYBLabelEditText @JvmOverloads constructor(
         }
     }
 
+    private fun isKeyboardShown(): Boolean {
+        val rootView = binding.etInput.rootView
+        val softKeyboardHeight = 100
+        val r = Rect()
+        rootView.getWindowVisibleDisplayFrame(r)
+        val dm = rootView.resources.displayMetrics
+        val heightDiff = rootView.bottom - r.bottom
+        return heightDiff > softKeyboardHeight * dm.density
+    }
+
     fun setTextInputFilter() {
         val pattern = "^[_.a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\u318D\\u119E\\u11A2\\u2022\\u2025a\\u00B7\\uFE55]*$"
         val inputFilter = InputFilter { source, _, _, _, _, _ ->
@@ -123,6 +135,23 @@ class WYBLabelEditText @JvmOverloads constructor(
             if (!hasFocus) {
                 hideKeyboard(activity, v)
             }
+        }
+    }
+
+    fun addOnGlobalLayoutListener(scrollView: ScrollView) {
+        binding.etInput.viewTreeObserver.addOnGlobalLayoutListener {
+            if (isKeyboardShown()) {
+                scrollToBottom(scrollView)
+            }
+        }
+    }
+
+    private fun scrollToBottom(scrollView: ScrollView) {
+        scrollView.apply {
+            val lastChild = getChildAt(0)
+            val bottom = lastChild.bottom + paddingBottom
+            val delta = bottom - (scrollY + height)
+            smoothScrollTo(0, delta)
         }
     }
 

--- a/app/src/main/res/layout/fragment_challenge_open_comfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_comfort.xml
@@ -18,7 +18,10 @@
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:clickable="true"
+            android:focusable="true"
+            android:focusableInTouchMode="true">
 
             <include
                 android:id="@+id/includeNavBar"

--- a/app/src/main/res/layout/fragment_challenge_open_comfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_comfort.xml
@@ -16,45 +16,49 @@
         android:fillViewport="true"
         tools:context=".ui.open.ChallengeOpenComfortFragment">
 
-        <LinearLayout
+        <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+            android:layout_height="wrap_content">
 
             <include
                 android:id="@+id/includeNavBar"
-                layout="@layout/include_challenge_open_nav" />
+                layout="@layout/include_challenge_open_nav"
+                app:layout_constraintTop_toTopOf="parent" />
 
             <TextView
+                android:id="@+id/tvTitle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginHorizontal="30dp"
                 android:layout_marginTop="40dp"
                 android:text="@string/challenge_open_comfort_title"
                 android:textAppearance="@style/TextAppearance.WYBComponents.Bold.30"
-                android:textColor="@color/dark_gray_2" />
+                android:textColor="@color/dark_gray_2"
+                app:layout_constraintTop_toBottomOf="@id/includeNavBar" />
 
             <com.wyb.wyb_android.widget.WYBLabelEditText
                 android:id="@+id/etComfort"
                 android:layout_width="match_parent"
-                android:layout_height="0dp"
+                android:layout_height="wrap_content"
                 android:layout_marginHorizontal="30dp"
                 android:layout_marginTop="40dp"
-                android:layout_weight="1"
                 app:hint="@{viewModel.randomHint}"
                 app:iconType="edit"
                 app:inputText="@={viewModel.comfort}"
                 app:labelText="@string/comfort"
+                app:layout_constraintTop_toBottomOf="@id/tvTitle"
                 app:setBackgroundStroke="@{viewModel.isInputEmpty ? @integer/wyb_label_edit_text_bg_stroke_gray : @integer/wyb_label_edit_text_bg_stroke_orange}"
                 app:showIcon="@{viewModel.isInputEmpty}" />
 
             <Button
                 android:id="@+id/btnNext"
                 style="@style/Widget.WYB.Button.SolidButton.FullWidth"
+                android:layout_width="match_parent"
                 android:enabled="@{!viewModel.isInputEmpty}"
-                android:text="@string/next" />
+                android:text="@string/next"
+                app:layout_constraintBottom_toBottomOf="parent" />
 
-        </LinearLayout>
+        </androidx.constraintlayout.widget.ConstraintLayout>
 
     </ScrollView>
 </layout>

--- a/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
@@ -21,6 +21,7 @@
             layout="@layout/include_challenge_open_nav" />
 
         <ScrollView
+            android:id="@+id/scrollView"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
@@ -58,6 +59,7 @@
                     android:layout_marginStart="30dp"
                     android:layout_marginTop="174dp"
                     android:layout_weight="1"
+                    android:paddingBottom="12dp"
                     android:text="@string/challenge_open_discomfort_guide"
                     android:textAppearance="@style/TextAppearance.WYBComponents.Medium.12"
                     android:textColor="@color/orange_alpha_60" />

--- a/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
@@ -64,15 +64,15 @@
                     android:textAppearance="@style/TextAppearance.WYBComponents.Medium.12"
                     android:textColor="@color/orange_alpha_60" />
 
-                <Button
-                    android:id="@+id/btnNext"
-                    style="@style/Widget.WYB.Button.SolidButton.FullWidth"
-                    android:enabled="@{viewModel.discomfort.length() != 0 ? true : false}"
-                    android:text="@string/next" />
-
             </LinearLayout>
 
         </ScrollView>
+
+        <Button
+            android:id="@+id/btnNext"
+            style="@style/Widget.WYB.Button.SolidButton.FullWidth"
+            android:enabled="@{viewModel.discomfort.length() != 0 ? true : false}"
+            android:text="@string/next" />
 
     </LinearLayout>
 </layout>

--- a/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
+++ b/app/src/main/res/layout/fragment_challenge_open_discomfort.xml
@@ -30,12 +30,12 @@
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:paddingHorizontal="30dp">
 
                 <TextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="30dp"
                     android:layout_marginTop="40dp"
                     android:text="@string/challenge_open_discomfort_title"
                     android:textAppearance="@style/TextAppearance.WYBComponents.Bold.30"
@@ -45,7 +45,6 @@
                     android:id="@+id/etDiscomfort"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_marginHorizontal="30dp"
                     android:layout_marginTop="40dp"
                     app:hint="@string/challenge_open_discomfort_hint"
                     app:inputText="@={viewModel.discomfort}"
@@ -53,11 +52,24 @@
                     app:setBackgroundStroke="@{viewModel.discomfort.length() != 0 ? @integer/wyb_label_edit_text_bg_stroke_orange : @integer/wyb_label_edit_text_bg_stroke_gray}"
                     app:showIcon="false" />
 
+                <androidx.recyclerview.widget.RecyclerView
+                    android:id="@+id/rvDiscomfort"
+                    style="@style/Widget.WYB.PopupWindow.Scrollbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="158dp"
+                    android:layout_marginTop="6dp"
+                    android:background="@drawable/shape_orange_stroke"
+                    android:clipToPadding="true"
+                    android:paddingHorizontal="5dp"
+                    android:paddingVertical="5dp"
+                    app:currentScrollPos="@={viewModel.discomfortScrollPos}"
+                    app:selectedPos="@={viewModel.discomfortPos}"
+                    tools:listitem="@layout/item_wyb_popup_window" />
+
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="0dp"
-                    android:layout_marginStart="30dp"
-                    android:layout_marginTop="174dp"
+                    android:layout_marginTop="10dp"
                     android:layout_weight="1"
                     android:paddingBottom="12dp"
                     android:text="@string/challenge_open_discomfort_guide"

--- a/app/src/main/res/layout/view_wyb_label_edit_text.xml
+++ b/app/src/main/res/layout/view_wyb_label_edit_text.xml
@@ -5,6 +5,9 @@
     android:id="@+id/layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:clickable="true"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
     android:orientation="vertical"
     android:paddingHorizontal="10dp"
     android:paddingVertical="8dp"
@@ -22,6 +25,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
+        android:duplicateParentState="true"
         android:orientation="horizontal">
 
         <EditText
@@ -31,6 +35,7 @@
             android:layout_marginEnd="5dp"
             android:layout_weight="1"
             android:background="@null"
+            android:duplicateParentState="true"
             android:importantForAutofill="no"
             android:inputType="text"
             android:maxLines="1"


### PR DESCRIPTION
## 📝 Changes
- **ChallengeOpenComfort**
    - keyboard show/hide 처리를 구현했습니다.
        - 처음 화면 진입/리로드 시에는 미노출
        - 입력박스를 클릭하면 노출
        - 입력박스 바깥 영역을 클릭하면 미노출

<br>

- **ChallengeOpenDiscomfort**
    - 해당 화면의 `WYBLabelEditText` 가 드롭다운의 **직접입력** 항목을 선택했을 때에만 활성화 되도록 구현했습니다.
    - 드롭다운에서 선택한 항목에 따라 keyboard show/hide 처리를 구현했습니다.
        - 직접입력 외 항목 선택 시 미노출
        - 직접입력 항목 선택 시 노출
        - 다시 다른 항목 선택하면 미노출
        - 입력박스 외 영역 클릭 시에도 항상 노출
    - 드롭다운에서 **직접입력** 항목 선택 시 화면 최하단으로 스크롤 되도록 구현했습니다.
    - 💡 스크롤 영역을 `progressBar` 하단부터 '다음' 버튼 상단까지로 변경했습니다.
    - 💡 스크롤 시 새로운 창으로 뜨는 `popupWindow` 에 하단 버튼이 가려지는 문제가 있어, 해당 화면에서는 `popupWindow` 대신 `recyclerView` 를 사용했습니다.

<br>

- **ETC**
    - `Utils.kt` 파일에 키보드를 내리는 기능만 포함되어 있는 `hidekeyboard` 함수를 추가했습니다.

<br>

## 📷 Screenshot
| | ChallengeOpenComfort | 💡 ChallengeOpenDiscomfort |
| ----- | :------------------------------: | :------------------------------: | 
| 구현화면 | <img src="https://user-images.githubusercontent.com/52772787/170023959-5ec96f96-8bb2-4eb8-a265-4d9ca0e1c85b.gif" width="240" /> | <img src="https://user-images.githubusercontent.com/52772787/170245254-eed8acc9-2194-45bd-b9a4-d41c3cbc0ac1.gif" width="240" /> |

<br>

## 💬 Comment
보고싶은 가은이.. 🔭

<br>