### PR TITLE
[feat] 닉네임 변경 기능, WYBLabelEditText CustomView 수정, TwoButtonDialog 제작

### DIFF
--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
@@ -44,6 +44,7 @@ class SettingProfileManagementFragment :
 
     private fun initView() {
         with(binding.etNickname) {
+            setTextInputFilter()
             setTextMaxLength(MAX_NICKNAME_LENGTH)
             etInput.setImeActionLabel(
                 getString(R.string.complete),

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
@@ -10,8 +10,8 @@ import com.wyb.wyb_android.R
 import com.wyb.wyb_android.base.ViewModelFragment
 import com.wyb.wyb_android.databinding.FragmentSettingProfileManagementBinding
 import com.wyb.wyb_android.ui.setting.SettingViewModel.Companion.MAX_NICKNAME_LENGTH
-import com.wyb.wyb_android.ui.setting.dialog.TwoButtonDialog
-import com.wyb.wyb_android.ui.setting.dialog.TwoButtonDialog.Companion.WITHDRAWAL
+import com.wyb.wyb_android.widget.dialog.TwoButtonDialog
+import com.wyb.wyb_android.widget.dialog.TwoButtonDialog.Companion.WITHDRAWAL
 import kotlinx.android.synthetic.main.view_wyb_label_edit_text.view.*
 
 class SettingProfileManagementFragment :

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
@@ -28,7 +28,7 @@ class SettingProfileManagementFragment :
         binding.layoutTitle.btnBack.setOnClickListener {
             findNavController().popBackStack()
         }
-        binding.etNickname.ivIcon.setOnClickListener {
+        binding.etNickname.cbIcon.setOnClickListener {
             navigateToHomeFragment()
         }
         binding.etNickname.etInput.setOnEditorActionListener(
@@ -54,7 +54,7 @@ class SettingProfileManagementFragment :
     }
 
     private fun navigateToHomeFragment() {
-        if(!binding.etNickname.ivIcon.isChecked) {
+        if(!binding.etNickname.cbIcon.isChecked) {
             findNavController().navigate(R.id.actionSettingProfileManagementToHome)
         }
     }

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
@@ -10,6 +10,8 @@ import com.wyb.wyb_android.R
 import com.wyb.wyb_android.base.ViewModelFragment
 import com.wyb.wyb_android.databinding.FragmentSettingProfileManagementBinding
 import com.wyb.wyb_android.ui.setting.SettingViewModel.Companion.MAX_NICKNAME_LENGTH
+import com.wyb.wyb_android.ui.setting.dialog.TwoButtonDialog
+import com.wyb.wyb_android.ui.setting.dialog.TwoButtonDialog.Companion.WITHDRAWAL
 import kotlinx.android.synthetic.main.view_wyb_label_edit_text.view.*
 
 class SettingProfileManagementFragment :
@@ -27,6 +29,11 @@ class SettingProfileManagementFragment :
     private fun addListener() {
         binding.layoutTitle.btnBack.setOnClickListener {
             findNavController().popBackStack()
+        }
+        binding.tvWithdraw.setOnClickListener {
+            TwoButtonDialog(WITHDRAWAL) {
+                // 탈퇴 처리
+            }.show(childFragmentManager, "WITHDRAWAL_DIALOG")
         }
         binding.etNickname.cbIcon.setOnClickListener {
             navigateToHomeFragment()
@@ -56,7 +63,7 @@ class SettingProfileManagementFragment :
     }
 
     private fun navigateToHomeFragment() {
-        if(!binding.etNickname.cbIcon.isChecked) {
+        if (!binding.etNickname.cbIcon.isChecked) {
             findNavController().navigate(R.id.actionSettingProfileManagementToHome)
         }
     }

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
@@ -2,22 +2,35 @@ package com.wyb.wyb_android.ui.setting
 
 import android.os.Bundle
 import android.view.View
+import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.wyb.wyb_android.R
-import com.wyb.wyb_android.base.BindingFragment
+import com.wyb.wyb_android.base.ViewModelFragment
 import com.wyb.wyb_android.databinding.FragmentSettingProfileManagementBinding
+import com.wyb.wyb_android.ui.setting.SettingViewModel.Companion.MAX_NICKNAME_LENGTH
 
-class SettingProfileManagementFragment : BindingFragment<FragmentSettingProfileManagementBinding>(
-    R.layout.fragment_setting_profile_management
-) {
+
+class SettingProfileManagementFragment :
+    ViewModelFragment<FragmentSettingProfileManagementBinding, SettingViewModel>(
+        R.layout.fragment_setting_profile_management
+    ) {
+    override val viewModel: SettingViewModel by viewModels()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        initView()
         addListener()
     }
 
     private fun addListener() {
         binding.layoutTitle.btnBack.setOnClickListener {
             findNavController().popBackStack()
+        }
+    }
+
+    private fun initView() {
+        with(binding.etNickname) {
+            setTextMaxLength(MAX_NICKNAME_LENGTH)
         }
     }
 }

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
@@ -44,6 +44,8 @@ class SettingProfileManagementFragment :
 
     private fun initView() {
         with(binding.etNickname) {
+            setEditTextNotFocusable(activity)
+            setCheckBoxMode(activity)
             setTextInputFilter()
             setTextMaxLength(MAX_NICKNAME_LENGTH)
             etInput.setImeActionLabel(

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
@@ -2,13 +2,15 @@ package com.wyb.wyb_android.ui.setting
 
 import android.os.Bundle
 import android.view.View
+import android.view.inputmethod.EditorInfo
+import android.widget.TextView.OnEditorActionListener
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.wyb.wyb_android.R
 import com.wyb.wyb_android.base.ViewModelFragment
 import com.wyb.wyb_android.databinding.FragmentSettingProfileManagementBinding
 import com.wyb.wyb_android.ui.setting.SettingViewModel.Companion.MAX_NICKNAME_LENGTH
-
+import kotlinx.android.synthetic.main.view_wyb_label_edit_text.view.*
 
 class SettingProfileManagementFragment :
     ViewModelFragment<FragmentSettingProfileManagementBinding, SettingViewModel>(
@@ -26,11 +28,33 @@ class SettingProfileManagementFragment :
         binding.layoutTitle.btnBack.setOnClickListener {
             findNavController().popBackStack()
         }
+        binding.etNickname.ivIcon.setOnClickListener {
+            navigateToHomeFragment()
+        }
+        binding.etNickname.etInput.setOnEditorActionListener(
+            OnEditorActionListener { _, actionId, _ ->
+                if (actionId == EditorInfo.IME_ACTION_DONE) {
+                    navigateToHomeFragment()
+                    return@OnEditorActionListener true
+                }
+                false
+            }
+        )
     }
 
     private fun initView() {
         with(binding.etNickname) {
             setTextMaxLength(MAX_NICKNAME_LENGTH)
+            etInput.setImeActionLabel(
+                getString(R.string.complete),
+                EditorInfo.IME_ACTION_DONE
+            )
+        }
+    }
+
+    private fun navigateToHomeFragment() {
+        if(!binding.etNickname.ivIcon.isChecked) {
+            findNavController().navigate(R.id.actionSettingProfileManagementToHome)
         }
     }
 }

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingProfileManagementFragment.kt
@@ -36,7 +36,9 @@ class SettingProfileManagementFragment :
             }.show(childFragmentManager, "WITHDRAWAL_DIALOG")
         }
         binding.etNickname.cbIcon.setOnClickListener {
-            navigateToHomeFragment()
+            if (!binding.etNickname.cbIcon.isChecked) {
+                navigateToHomeFragment()
+            }
         }
         binding.etNickname.etInput.setOnEditorActionListener(
             OnEditorActionListener { _, actionId, _ ->
@@ -63,8 +65,6 @@ class SettingProfileManagementFragment :
     }
 
     private fun navigateToHomeFragment() {
-        if (!binding.etNickname.cbIcon.isChecked) {
-            findNavController().navigate(R.id.actionSettingProfileManagementToHome)
-        }
+        findNavController().navigate(R.id.actionSettingProfileManagementToHome)
     }
 }

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingViewModel.kt
@@ -1,0 +1,17 @@
+package com.wyb.wyb_android.ui.setting
+
+import androidx.lifecycle.MediatorLiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+
+class SettingViewModel : ViewModel() {
+    val userNickname = MutableLiveData("")
+
+    val nicknameMaxLength = MediatorLiveData<Boolean>().apply {
+        addSource(userNickname) { this.value = it.length >= MAX_NICKNAME_LENGTH}
+    }
+
+    companion object {
+        const val MAX_NICKNAME_LENGTH = 7
+    }
+}

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingViewModel.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/SettingViewModel.kt
@@ -7,7 +7,7 @@ import androidx.lifecycle.ViewModel
 class SettingViewModel : ViewModel() {
     val userNickname = MutableLiveData("")
 
-    val nicknameMaxLength = MediatorLiveData<Boolean>().apply {
+    val isNicknameLengthValid = MediatorLiveData<Boolean>().apply {
         addSource(userNickname) { this.value = it.length >= MAX_NICKNAME_LENGTH}
     }
 

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/dialog/TwoButtonDialog.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/dialog/TwoButtonDialog.kt
@@ -1,0 +1,60 @@
+package com.wyb.wyb_android.ui.setting.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import com.wyb.wyb_android.R
+import com.wyb.wyb_android.databinding.DialogTwoButtonBinding
+
+class TwoButtonDialog(
+    private val dialogMode: Int,
+) : DialogFragment() {
+    private lateinit var binding: DialogTwoButtonBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = DialogTwoButtonBinding.inflate(layoutInflater, container, false)
+        initView()
+        return binding.root
+    }
+
+    override fun onResume() {
+        super.onResume()
+        setLayout()
+    }
+
+    private fun setLayout() {
+        val dialogWidth = (resources.displayMetrics.widthPixels * 0.8).toInt()
+        requireNotNull(dialog).apply {
+            requireNotNull(window).apply {
+                setLayout(
+                    dialogWidth,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                )
+            }
+        }
+    }
+
+    private fun initView() {
+        when (dialogMode) {
+            WITHDRAWAL -> setText(
+                title = getString(R.string.withdraw_title),
+                titleSub = getString(R.string.withdraw_title_sub),
+            )
+        }
+    }
+
+    private fun setText(title: String, titleSub: String) {
+        binding.tvTitle.text = title
+        binding.tvTitleSub.text = titleSub
+    }
+
+    companion object {
+        const val WITHDRAWAL = 0
+    }
+}

--- a/app/src/main/java/com/wyb/wyb_android/ui/setting/dialog/TwoButtonDialog.kt
+++ b/app/src/main/java/com/wyb/wyb_android/ui/setting/dialog/TwoButtonDialog.kt
@@ -10,6 +10,7 @@ import com.wyb.wyb_android.databinding.DialogTwoButtonBinding
 
 class TwoButtonDialog(
     private val dialogMode: Int,
+    private val doAfterConfirm: () -> Unit
 ) : DialogFragment() {
     private lateinit var binding: DialogTwoButtonBinding
 
@@ -20,6 +21,7 @@ class TwoButtonDialog(
     ): View {
         binding = DialogTwoButtonBinding.inflate(layoutInflater, container, false)
         initView()
+        addListener()
         return binding.root
     }
 
@@ -52,6 +54,17 @@ class TwoButtonDialog(
     private fun setText(title: String, titleSub: String) {
         binding.tvTitle.text = title
         binding.tvTitleSub.text = titleSub
+    }
+
+    private fun addListener() {
+        binding.tvConfirm.setOnClickListener {
+            doAfterConfirm()
+            dismiss()
+        }
+
+        binding.tvCancel.setOnClickListener {
+            dismiss()
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
@@ -63,15 +63,15 @@ class WYBLabelEditText @JvmOverloads constructor(
         }
 
     var showIcon: Boolean
-        get() = binding.ivIcon.isVisible
+        get() = binding.cbIcon.isVisible
         set(value) {
-            binding.ivIcon.isVisible = value
+            binding.cbIcon.isVisible = value
         }
 
     var iconType: Drawable?
-        get() = binding.ivIcon.drawable
+        get() = binding.cbIcon.background
         set(value) {
-            binding.ivIcon.setImageDrawable(value)
+            binding.cbIcon.background = value
         }
 
     private fun initializeAttrs(context: Context, attrs: AttributeSet?) {
@@ -80,10 +80,7 @@ class WYBLabelEditText @JvmOverloads constructor(
             labelText = it.getString(R.styleable.WYBLabelEditText_labelText)
             hint = it.getString(R.styleable.WYBLabelEditText_hint)
             showIcon = it.getBoolean(R.styleable.WYBLabelEditText_showIcon, false)
-            iconType = when (it.getInt(R.styleable.WYBLabelEditText_iconType, TYPE_CHECK)) {
-                TYPE_EDIT -> ResourcesCompat.getDrawable(resources, R.drawable.ic_edit, null)
-                else -> ResourcesCompat.getDrawable(resources, R.drawable.ic_check_20, null)
-            }
+            setIconType(it.getInt(R.styleable.WYBLabelEditText_iconType, TYPE_CHECK))
             setBackgroundStroke(it.getInt(R.styleable.WYBLabelEditText_backgroundStroke, COLOR_ORANGE))
             it.recycle()
         }
@@ -122,6 +119,13 @@ class WYBLabelEditText @JvmOverloads constructor(
         backgroundStroke = when (color) {
             COLOR_GRAY -> ResourcesCompat.getDrawable(resources, R.drawable.shape_gray2_stroke, null)
             else -> ResourcesCompat.getDrawable(resources, R.drawable.shape_orange_stroke, null)
+        }
+    }
+
+    fun setIconType(type: Int) {
+        iconType = when (type) {
+            TYPE_EDIT -> ResourcesCompat.getDrawable(resources, R.drawable.ic_edit, null)
+            else -> ResourcesCompat.getDrawable(resources, R.drawable.ic_check_20, null)
         }
     }
 

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
@@ -171,6 +171,21 @@ class WYBLabelEditText @JvmOverloads constructor(
         hideKeyboard(activity, binding.etInput)
     }
 
+    fun setCheckBoxMode(activity: Activity?) {
+        binding.cbIcon.setOnCheckedChangeListener { _, isChecked ->
+            when (isChecked) {
+                true -> {
+                    setIconType(TYPE_CHECK)
+                    setEditTextFocusable()
+                }
+                else ->  {
+                    setIconType(TYPE_EDIT)
+                    setEditTextNotFocusable(activity)
+                }
+            }
+        }
+    }
+
     companion object {
         private const val COLOR_GRAY = 0
         private const val COLOR_ORANGE = 1

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
@@ -97,7 +97,7 @@ class WYBLabelEditText @JvmOverloads constructor(
     }
 
     fun setTextInputFilter() {
-        val pattern = "^[_.a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\u318D\\u119E\\u11A2\\u2022\\u2025\\u00B7\\uFE55\\u3161\\u3163]*$"
+        val pattern = "^[_a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\u318D\\u119E\\u11A2\\u2022\\u2025\\u00B7\\uFE55\\u3161\\u3163]*$"
         val inputFilter = InputFilter { source, _, _, _, _, _ ->
             if (!source.matches(Regex(pattern))) return@InputFilter ""
             null

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
@@ -100,7 +100,7 @@ class WYBLabelEditText @JvmOverloads constructor(
     }
 
     fun setTextInputFilter() {
-        val pattern = "^[_.a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\u318D\\u119E\\u11A2\\u2022\\u2025a\\u00B7\\uFE55]*$"
+        val pattern = "^[_.a-zA-Z0-9가-힣ㄱ-ㅎㅏ-ㅣ\\u318D\\u119E\\u11A2\\u2022\\u2025\\u00B7\\uFE55\\u3161\\u3163]*$"
         val inputFilter = InputFilter { source, _, _, _, _, _ ->
             if (!source.matches(Regex(pattern))) return@InputFilter ""
             null

--- a/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/WYBLabelEditText.kt
@@ -122,7 +122,7 @@ class WYBLabelEditText @JvmOverloads constructor(
         }
     }
 
-    fun setIconType(type: Int) {
+    private fun setIconType(type: Int) {
         iconType = when (type) {
             TYPE_EDIT -> ResourcesCompat.getDrawable(resources, R.drawable.ic_edit, null)
             else -> ResourcesCompat.getDrawable(resources, R.drawable.ic_check_20, null)

--- a/app/src/main/java/com/wyb/wyb_android/widget/dialog/TwoButtonDialog.kt
+++ b/app/src/main/java/com/wyb/wyb_android/widget/dialog/TwoButtonDialog.kt
@@ -1,4 +1,4 @@
-package com.wyb.wyb_android.ui.setting.dialog
+package com.wyb.wyb_android.widget.dialog
 
 import android.os.Bundle
 import android.view.LayoutInflater

--- a/app/src/main/res/layout/dialog_two_button.xml
+++ b/app/src/main/res/layout/dialog_two_button.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@color/white"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="40dp"
+        android:textAppearance="@style/TextAppearance.WYBComponents.Bold.16"
+        android:textColor="@color/dark_gray_2"
+        tools:text="@string/withdraw_title" />
+
+    <TextView
+        android:id="@+id/tvTitleSub"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:layout_marginTop="12dp"
+        android:textAppearance="@style/TextAppearance.WYBComponents.Medium.13"
+        android:textColor="@color/gray_4"
+        tools:text="@string/withdraw_title_sub" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="40dp"
+        android:background="@color/light_gray_2" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/tvConfirm"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@color/white"
+            android:gravity="center"
+            android:paddingVertical="16dp"
+            android:text="@string/confirm"
+            android:textAppearance="@style/TextAppearance.WYBComponents.Bold.14"
+            android:textColor="@color/gray_2" />
+
+        <TextView
+            android:id="@+id/tvCancel"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:background="@color/orange"
+            android:gravity="center"
+            android:paddingVertical="16dp"
+            android:text="@string/cancel"
+            android:textAppearance="@style/TextAppearance.WYBComponents.Bold.14"
+            android:textColor="@color/white" />
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_setting_profile_management.xml
+++ b/app/src/main/res/layout/fragment_setting_profile_management.xml
@@ -48,7 +48,7 @@
             app:layout_constraintTop_toBottomOf="@id/etNickname" />
 
         <TextView
-            isVisibleOrInvisible="@{viewModel.nicknameMaxLength}"
+            isVisibleOrInvisible="@{viewModel.isNicknameLengthValid}"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"

--- a/app/src/main/res/layout/fragment_setting_profile_management.xml
+++ b/app/src/main/res/layout/fragment_setting_profile_management.xml
@@ -2,6 +2,13 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.wyb.wyb_android.ui.setting.SettingViewModel" />
+    </data>
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
@@ -22,6 +29,7 @@
             app:backgroundStroke="gray"
             app:hint="@string/setting_nickname_hint"
             app:iconType="edit"
+            app:inputText="@={viewModel.userNickname}"
             app:labelText="@string/nickname"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -33,6 +41,18 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="12dp"
             android:text="@string/nickname_alert_message"
+            android:textAppearance="@style/TextAppearance.WYBComponents.Medium.12"
+            android:textColor="@color/red_alert"
+            android:visibility="invisible"
+            app:layout_constraintStart_toStartOf="@id/etNickname"
+            app:layout_constraintTop_toBottomOf="@id/etNickname" />
+
+        <TextView
+            isVisibleOrInvisible="@{viewModel.nicknameMaxLength}"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/nickname_max_length_message"
             android:textAppearance="@style/TextAppearance.WYBComponents.Medium.12"
             android:textColor="@color/red_alert"
             android:visibility="invisible"

--- a/app/src/main/res/layout/view_wyb_label_edit_text.xml
+++ b/app/src/main/res/layout/view_wyb_label_edit_text.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/layout"
     android:layout_width="match_parent"
@@ -44,12 +43,14 @@
             android:textColorHint="@color/gray_2"
             tools:hint="@string/challenge_open_comfort_hint" />
 
-        <ImageView
-            android:id="@+id/ivIcon"
+        <CheckBox
+            android:id="@+id/cbIcon"
             android:layout_width="20dp"
             android:layout_height="20dp"
-            app:tint="@color/orange"
-            tools:src="@drawable/ic_edit" />
+            android:backgroundTint="@color/orange"
+            android:button="@android:color/transparent"
+            android:checked="false"
+            tools:background="@drawable/ic_edit" />
 
     </LinearLayout>
 

--- a/app/src/main/res/navigation/setting_nav_graph.xml
+++ b/app/src/main/res/navigation/setting_nav_graph.xml
@@ -43,7 +43,14 @@
         android:id="@+id/settingProfileManagementFragment"
         android:name="com.wyb.wyb_android.ui.setting.SettingProfileManagementFragment"
         android:label="SettingProfileManagementFragment"
-        tools:layout="@layout/fragment_setting_profile_management" />
+        tools:layout="@layout/fragment_setting_profile_management" >
+
+        <action
+            android:id="@+id/actionSettingProfileManagementToHome"
+            app:destination="@id/HomeFragment"
+            app:popUpTo="@id/settingFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
 
     <fragment
         android:id="@+id/settingTermsFragment"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,10 @@
     <string name="nickname">닉네임</string>
 
     <!-- Dialog -->
+    <string name="confirm">확인</string>
+    <string name="cancel">취소</string>
+    <string name="withdraw_title">계정을 정말 삭제하시겠습니까?</string>
+    <string name="withdraw_title_sub">모든 정보가 완전히 삭제됩니다</string>
 
     <!-- WYBChallengeEditText -->
     <string name="challenge_et_hint">참을 수 있는 불편함을 적어주세요</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -86,6 +86,7 @@
     <string name="setting_profile_exposure_sub_title">둘러보기에서 내 보틀을 다른 사용자에게 보여줍니다</string>
     <string name="setting_nickname_hint">닉네임을 입력해 주세요</string>
     <string name="nickname_alert_message">이미 사용 중이에요! 다른 닉네임을 적어주세요</string>
+    <string name="nickname_max_length_message">6자까지만 입력할 수 있어요!</string>
     <string name="setting_logout">로그아웃</string>
     <string name="setting_withdraw">탈퇴하기</string>
 </resources>


### PR DESCRIPTION
## 📝 Changes
- **SettingProfileManagementFragment**
    -  기존 제작되어 있는 WYBLableEditText 커스텀 뷰를 활용하여 닉네임 변경 기능을 추가하였습니다.
    -  닉네임 변경 완료 시 홈 화면으로 이동하는 navigation action 연결.
    - `탈퇴하기` 버튼 클릭 시 TwoButtonDialog 연결.
    -  키보드의 action button 클릭 시 닉네임 변경 완료 기능과 동일하게 작동하도록 `OnEditorActionListener`를 추가하였습니다.
<br>

- **SettingViewModel**
    -  닉네임 텍스트를 databinding 으로 연결하여 글자수에 따라 경고 문구가 노출 되도록 하였습니다.
<br>

- **WYBLabelEditText**
    -  기존 `ImageView` 로 제작한 우측 아이콘을 `CheckBox` 위젯으로 변경하였습니다.
    - 닉네임 변경 시에는 아이콘 클릭으로 EditText가 편집 가능하도록 변경되어야 하며, 아이콘의 이미지도 변경되어야 하기 때문에 CheckBox로 변경하였습니다.
    - 해당 커스텀뷰를 사용하는 ChallengeOpen에서는 아이콘 클릭 관련 기능이 없어 기존과 동일하게 정상적으로 작동합니다.
    - `setCheckBoxMode()` 함수는 CheckBox의 체크 여부에 따라 **아이콘 이미지**와 **editText의 editable 여부**를 변경합니다.
    - 닉네임 입력 가능 문자는 `영어, 한글, 숫자, _` 만 가능하며, 기존 제작된 정규식을 보완하였습니다.
<br>

- **TwoButtonDialog**
    -  하단 버튼이 두개 있는 Dialog를 제작하였습니다. 추후 동일한 디자인으로 문구만 변경하여 재활용할 수 있습니다.
<br>

## 📷 Screenshot
| 기능 | 닉네임 변경 | 탈퇴 Dialog |
| ----- | :------------------------------: | :------------------------------: | 
| 스크린샷 | <img src="https://user-images.githubusercontent.com/53547556/212868013-bbe14ced-4a74-47d1-bafa-7d0453ecec75.gif" width="240" /> |<img src="https://user-images.githubusercontent.com/53547556/212867055-7a719339-4c53-43df-b77f-8e86111563ef.gif" width="240" /> |


## 💬 Comment
TwoButtonDialog.kt 파일을 어디 package에 넣을까 고민하다가.. 사용되는 곳이 설정 부분 밖에 없어서 우선 설정 폴더의 하위폴더로 넣어놨습니다! 좋은 의견 있으면 공유부탁드림니다 🌚
